### PR TITLE
Renamed filter_ to filter

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -16,7 +16,7 @@ permissions of your API token.
 .. code:: python
 
    # Retrieve a user
-   user = rc.users.list(filter_={"email": "researcher@example.com"})[0]
+   user = rc.users.list(filter={"email": "researcher@example.com"})[0]
 
    # Retrieve a list of clients.
    clients = rc.clients.list()
@@ -59,17 +59,13 @@ as arguments.
    print([t.name for t in finding.targets])
    # ["Acceptance Environment", "Production Environment"]
 
-.. note::
-   The query parameter :code:`filter` is called :code:`filter_` in python-reporter to avoid clashes with the
-   :code:`filter` keyword, as prescribed in https://peps.python.org/pep-0008/#descriptive-naming-styles
-
 The following demonstrates how to update a finding:
 
 .. code:: python
 
    from reporter import Reporter
    rc = Reporter(url="https://reporter.example.com", api_token="secret")
-   finding = rc.findings.list(filter_={"title": "Incoming Meteor"})[0]
+   finding = rc.findings.list(filter={"title": "Incoming Meteor"})[0]
    rc.findings.update(finding.id, {
        "risk": "This is a massive risk to the entire planet.",
        "targets": [target_id],

--- a/reporter/mixins.py
+++ b/reporter/mixins.py
@@ -223,7 +223,7 @@ class _ListMixin(Generic[ChildOfRestObject]):
         self,
         extra_path: str = "",
         term: Optional[str] = None,
-        filter_: Optional[Dict[str, str]] = None,
+        filter: Optional[Dict[str, str]] = None,
         sort: Optional[List[str]] = None,
         include: Optional[List[str]] = None,
         page: Optional[int] = None,
@@ -235,7 +235,7 @@ class _ListMixin(Generic[ChildOfRestObject]):
         Args:
             extra_path: Extra text to add to the request URL path
             term: A search term.
-            filter\\_: query string parameters for HTTP request of the form
+            filter: query string parameters for HTTP request of the form
                 filter[field]
             sort: How to sort retrieved items
             include: Types of related data to include
@@ -259,9 +259,9 @@ class _ListMixin(Generic[ChildOfRestObject]):
         if term is not None:
             query_data["term"] = term
 
-        if filter_ is None:
-            filter_ = {}
-        for (key, value) in filter_.items():
+        if filter is None:
+            filter = {}
+        for (key, value) in filter.items():
             query_data[f"filter[{key}]"] = value
 
         if include:
@@ -298,7 +298,7 @@ class ListMixin(_ListMixin):
 
     def list(  # pylint: disable = too-many-arguments
         self,
-        filter_: Optional[Dict[str, str]] = None,
+        filter: Optional[Dict[str, str]] = None,
         sort: Optional[List[str]] = None,
         include: Optional[List[str]] = None,
         page: Optional[int] = None,
@@ -308,7 +308,7 @@ class ListMixin(_ListMixin):
         """Retrieve a list of objects.
 
         Args:
-            filter\\_: query string parameters for HTTP request of the form
+            filter: query string parameters for HTTP request of the form
                 filter[field]
             sort: How to sort retrieved items
             include: Types of related data to include
@@ -327,7 +327,7 @@ class ListMixin(_ListMixin):
         """
         return self._get_list(
             extra_path="",
-            filter_=filter_,
+            filter=filter,
             sort=sort,
             include=include,
             page=page,

--- a/tests/functional/test_assessment.py
+++ b/tests/functional/test_assessment.py
@@ -31,7 +31,7 @@ def test_assessment_operations(rc: Reporter, client, assessment_template):
         }
     )
 
-    assert assessment in rc.assessments.list(filter_={"id": assessment.id})
+    assert assessment in rc.assessments.list(filter={"id": assessment.id})
 
     rc.assessments.update(assessment.id, {"internal_details": "foo"})
     gotten = rc.assessments.get(assessment.id)
@@ -131,7 +131,7 @@ def test_activities(rc: Reporter, client, assessment_template):
     )
 
     activity = rc.activities.list(
-        filter_={
+        filter={
             "assessment_id": assessment.id,
             "type": "40",
         }

--- a/tests/functional/test_finding.py
+++ b/tests/functional/test_finding.py
@@ -30,7 +30,7 @@ def test_target_operations(rc: Reporter, assessment):
         }
     )
 
-    assert target in rc.targets.list(filter_={"id": target.id})
+    assert target in rc.targets.list(filter={"id": target.id})
 
     rc.targets.update(target.id, {"description": "foo"})
     gotten = rc.targets.get(target.id)
@@ -69,7 +69,7 @@ def test_finding_operations(rc: Reporter, assessment):
         }
     )
 
-    assert finding in rc.findings.list(filter_={"id": finding.id})
+    assert finding in rc.findings.list(filter={"id": finding.id})
 
     rc.findings.update(finding.id, {"description": "bar"})
     gotten = rc.findings.get(finding.id)
@@ -97,7 +97,7 @@ def test_finding_template_operations(rc: Reporter):
         }
     )
 
-    assert template in rc.finding_templates.list(filter_={"id": template.id})
+    assert template in rc.finding_templates.list(filter={"id": template.id})
 
     rc.finding_templates.update(template.id, {"risk": "bar"})
     gotten = rc.finding_templates.get(template.id)

--- a/tests/functional/test_user.py
+++ b/tests/functional/test_user.py
@@ -12,7 +12,7 @@ def test_user_operations(rc: Reporter):
     }
     user = rc.users.create(user_data)
 
-    assert user in rc.users.list(filter_={"id": user.id})
+    assert user in rc.users.list(filter={"id": user.id})
 
     rc.users.update(user.id, {"phone": "foo"})
     gotten = rc.users.get(user.id)
@@ -31,7 +31,7 @@ def test_client_operations(rc: Reporter):
         }
     )
 
-    assert client in rc.clients.list(filter_={"id": client.id})
+    assert client in rc.clients.list(filter={"id": client.id})
 
     rc.clients.update(client.id, {"website": "https://example.com"})
     gotten = rc.clients.get(client.id)
@@ -79,7 +79,7 @@ def test_user_group_operations(rc: Reporter):
         }
     )
 
-    assert group in rc.user_groups.list(filter_={"id": group.id})
+    assert group in rc.user_groups.list(filter={"id": group.id})
 
     rc.user_groups.update(group.id, {"color": "#111111"})
     gotten = rc.user_groups.get(group.id)


### PR DESCRIPTION
Renamed the `filter_` parameter for `.list()` and `.search()` to `filter`, because there is no actual collision.