### PR TITLE
Add support for creating findings from finding templates

### DIFF
--- a/reporter/objects/finding.py
+++ b/reporter/objects/finding.py
@@ -1,5 +1,6 @@
 # pylint: disable = missing-module-docstring, missing-class-docstring
 
+from typing import Any, Dict, TYPE_CHECKING
 from reporter.base import RestManager, RestObject
 from reporter.mixins import CreateMixin, DeleteMixin, GetMixin, ListMixin, UpdateMixin
 
@@ -23,3 +24,36 @@ class AssessmentFindingManager(RestManager, CreateMixin):
     _path = "assessments/{assessment_id}/findings"
     _parent_attrs = {"assessment_id": "id"}
     _obj_cls = Finding
+
+    def create_from_template(
+        self, template_id: str, attrs: Dict[str, Any], **kwargs: Any
+    ) -> Finding:
+        """Create a new finding from a finding template
+
+        Args:
+            template_id: The ID of the finding template.
+            attrs: Attributes for the created finding.
+            kwargs: Extra options to pass to the underlying
+                :func:`reporter.Reporter.http_request` call.
+
+        Returns:
+            The response from the server, serialized into the `Finding` type.
+
+        Raises:
+            ReporterHttpError: If raised by the underlying call to
+                :func:`reporter.Reporter.http_request`.
+
+        """
+        if TYPE_CHECKING:
+            assert isinstance(self._parent, RestObject)
+        path = f"assessments/{self._parent.id}/finding-templates/{template_id}/findings"
+        result = self.reporter.http_request(
+            verb="post",
+            path=path,
+            post_data=attrs,
+            files=None,
+            **kwargs,
+        )
+        if TYPE_CHECKING:
+            assert isinstance(result, dict)
+        return Finding(self.reporter, result.json())


### PR DESCRIPTION
Adds support to the `AssessmentFindingManager` for the new API route `/assessments/{assessment_id}/finding-templates/{finding_template}/findings`.

If `assessment` is an instance of `Assessment`, create a new finding from a finding template using `assessment.findings.create_from_template(template_id, attrs)`.