### PR TITLE
Allow for multiple tags search

### DIFF
--- a/reporter/mixins.py
+++ b/reporter/mixins.py
@@ -260,7 +260,10 @@ class _ListMixin(Generic[ChildOfRestObject]):
         if filter is None:
             filter = {}
         for key, value in filter.items():
-            query_data[f"filter[{key}]"] = value
+            if key == "tags":
+                query_data[f"filter[{key}][]"] = value
+            else:
+                query_data[f"filter[{key}]"] = value
 
         if include:
             query_data["include"] = ",".join(include)


### PR DESCRIPTION
Previously when looking for tags, only the last one was taken in account:

```python
self.reporter.finding_templates.list(filter={"tags": ["Web", "Network"]}, **other_args)
```
The above line will only take the tags Network- for listing vuln.

With this PR, all tags will be used.