### PR TITLE
Suppress pylint errors caused by update

### DIFF
--- a/reporter/client.py
+++ b/reporter/client.py
@@ -88,7 +88,7 @@ class Reporter:  # pylint: disable = too-many-instance-attributes, too-few-publi
         self.users = objects.UserManager(self)
         self.webhooks = objects.WebhookManager(self)
 
-    def http_request(  # pylint: disable = too-many-arguments
+    def http_request(  # pylint: disable = too-many-arguments, too-many-positional-arguments
         self,
         verb: str,
         path: str,

--- a/reporter/mixins.py
+++ b/reporter/mixins.py
@@ -216,7 +216,7 @@ class _ListMixin(Generic[ChildOfRestObject]):
     _obj_cast: Callable
     reporter: Reporter
 
-    def _get_list(  # pylint: disable = too-many-arguments, too-many-locals, redefined-builtin
+    def _get_list(  # pylint: disable = too-many-arguments, too-many-positional-arguments, too-many-locals, redefined-builtin
         self,
         extra_path: str = "",
         term: Optional[str] = None,
@@ -297,7 +297,7 @@ class _ListMixin(Generic[ChildOfRestObject]):
 class ListMixin(_ListMixin):
     """Manager can list objects."""
 
-    def list(  # pylint: disable = too-many-arguments, redefined-builtin
+    def list(  # pylint: disable = too-many-arguments, too-many-positional-arguments, redefined-builtin
         self,
         filter: Optional[Mapping[str, str]] = None,
         sort: Optional[List[str]] = None,


### PR DESCRIPTION
In a recent pylint update, a rule `too-many-positional-arguments` was added. We already suppressed the rule `too-many-arguments` in some places, and this PR suppresses the new rule in those same places.

Another solution would've been to force [keyword-only arguments](https://peps.python.org/pep-3102/) but I didn't want to introduce any breaking changes.