### PR TITLE
Allow lists and comma-separated strings for filters, includes, and sorts

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,3 +2,4 @@
 exclude_lines=
     pragma: no cover
     if TYPE_CHECKING:
+    @overload

--- a/reporter/client.py
+++ b/reporter/client.py
@@ -88,7 +88,7 @@ class Reporter:  # pylint: disable = too-many-instance-attributes, too-few-publi
         self.users = objects.UserManager(self)
         self.webhooks = objects.WebhookManager(self)
 
-    def http_request(  # pylint: disable = too-many-arguments, too-many-positional-arguments
+    def http_request(  # pylint: disable = too-many-arguments, too-many-positional-arguments, too-many-locals
         self,
         verb: str,
         path: str,
@@ -131,12 +131,20 @@ class Reporter:  # pylint: disable = too-many-instance-attributes, too-few-publi
             data = None
             json = post_data
 
+        params = {}
+        if query_data:
+            for key, value in query_data.items():
+                if isinstance(value, list):
+                    params[f"{key}[]"] = value
+                else:
+                    params[key] = value
+
         for i in range(2):
             result = self.session.request(  # pylint: disable = too-many-arguments
                 method=verb,
                 url=url,
                 headers=headers,
-                params=query_data,
+                params=params,
                 data=data,
                 json=json,
                 files=files,

--- a/reporter/mixins.py
+++ b/reporter/mixins.py
@@ -131,8 +131,8 @@ class GetMixin(Generic[ChildOfRestObject]):
     def get(
         self,
         id: str,
-        include: Optional[List[str]] = None,
-        query_data: Optional[Mapping[str, str]] = None,
+        include: Optional[str | List[str]] = None,
+        query_data: Optional[Mapping[str, Any]] = None,
         **kwargs: Any,
     ) -> ChildOfRestObject:
         """Retrieve a single object.
@@ -156,7 +156,8 @@ class GetMixin(Generic[ChildOfRestObject]):
         query_data = dict(query_data) if query_data else {}
 
         if include:
-            query_data["include"] = ",".join(include)
+            query_data["include"] = include
+
         path = f"{self._path}/{id}"
 
         result = self.reporter.http_request(
@@ -220,12 +221,12 @@ class _ListMixin(Generic[ChildOfRestObject]):
         self,
         extra_path: str = "",
         term: Optional[str] = None,
-        filter: Optional[Mapping[str, str]] = None,
-        sort: Optional[List[str]] = None,
-        include: Optional[List[str]] = None,
+        filter: Optional[Mapping[str, str | int | List[str | int]]] = None,
+        sort: Optional[str | List[str]] = None,
+        include: Optional[str | List[str]] = None,
         page: Optional[int] = None,
         page_size: Optional[int] = None,
-        query_data: Optional[Mapping[str, str]] = None,
+        query_data: Optional[Mapping[str, Any]] = None,
         **kwargs: Any,
     ) -> RestList:
         """Retrieve a list of objects.
@@ -263,10 +264,10 @@ class _ListMixin(Generic[ChildOfRestObject]):
             query_data[f"filter[{key}]"] = value
 
         if include:
-            query_data["include"] = ",".join(include)
+            query_data["include"] = include
 
-        if sort is not None and sort != []:
-            query_data["sort"] = ",".join(sort)
+        if sort:
+            query_data["sort"] = sort
 
         if page is not None:
             query_data["page[number]"] = str(page)
@@ -299,12 +300,12 @@ class ListMixin(_ListMixin):
 
     def list(  # pylint: disable = too-many-arguments, too-many-positional-arguments, redefined-builtin
         self,
-        filter: Optional[Mapping[str, str]] = None,
-        sort: Optional[List[str]] = None,
-        include: Optional[List[str]] = None,
+        filter: Optional[Mapping[str, str | int | List[str | int]]] = None,
+        sort: Optional[str | List[str]] = None,
+        include: Optional[str | List[str]] = None,
         page: Optional[int] = None,
         page_size: Optional[int] = None,
-        query_data: Optional[Mapping[str, str]] = None,
+        query_data: Optional[Mapping[str, Any]] = None,
         **kwargs: Any,
     ) -> RestList:
         """Retrieve a list of objects.
@@ -348,7 +349,7 @@ class SearchMixin(_ListMixin):
         term: Optional[str] = None,
         page: Optional[int] = None,
         page_size: Optional[int] = None,
-        query_data: Optional[Mapping[str, str]] = None,
+        query_data: Optional[Mapping[str, Any]] = None,
         **kwargs: Any,
     ) -> RestList:
         """Search for a list of objects.

--- a/reporter/objects/user.py
+++ b/reporter/objects/user.py
@@ -20,8 +20,8 @@ class UserManager(RestManager, CreateMixin, GetMixin, ListMixin, UpdateMixin):
 
     def me(
         self,
-        include: Optional[List[str]] = None,
-        query_data: Optional[Mapping[str, str]] = None,
+        include: Optional[str | List[str]] = None,
+        query_data: Optional[Mapping[str, Any]] = None,
         **kwargs: Any,
     ) -> User:
         """Get the user who owns the API token
@@ -44,7 +44,7 @@ class UserManager(RestManager, CreateMixin, GetMixin, ListMixin, UpdateMixin):
         query_data = dict(query_data) if query_data else {}
 
         if include:
-            query_data["include"] = ",".join(include)
+            query_data["include"] = include
 
         result = self.reporter.http_request(
             verb="get",


### PR DESCRIPTION
Closes #33

Filters, includes, and sorts can now be passed both as lists and comma-separated strings. Before, this was inconsistent.

Now both of these lines yield the same result:

```python
rc.findings.list(filter={"severity": "11,12"}, include="assessment,targets", sort="-severity,title")
rc.findings.list(filter={"severity": [11, 12]}, include=["assessment", "targets"], sort=["-severity", "title"])
```

The `query_data` parameter now works slightly differently. If one of its values is a list, the corresponding key is appended with `[]` to closer match the Reporter API. So `query_data={"a": [1,2]}` converts to the query string `a[]=1&a[]=2`.